### PR TITLE
Update alfred-placeholder-workflows.rb

### DIFF
--- a/alfred-placeholder-workflows.rb
+++ b/alfred-placeholder-workflows.rb
@@ -1,5 +1,5 @@
 class AlfredPlaceholderWorkflows < Formula
-  desc "Create dummy Alfred Workflows that update to their real counterparts, to host on Packal"
+  desc "Dummy Alfred Workflows for updating real counterparts hosted on Packal"
   homepage "https://github.com/vitorgalvao/tiny-alfred-scripts"
   url "https://github.com/vitorgalvao/tiny-alfred-scripts.git"
   version "0.0.1"


### PR DESCRIPTION
I was running some style checks on taps since updating to Big Sur and found some for the description lengths which are limited to 80 characters. Maybe this is an appropriate replacement?